### PR TITLE
Add expired token checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.css]
+indent_size = 2
+indent_style = space
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/scv-prototype-frontend/src/app/App.jsx
+++ b/scv-prototype-frontend/src/app/App.jsx
@@ -51,7 +51,7 @@ const App = (props) => {
 							<Route path="/sign-in" component={Login} exact />
 
 							{/* XXX :: GjB :: protected route for testing auth .. will remove later */}
-							<PrivateRoute path="/greeting" component={Greeting} authorities={['USER']} exact />
+							<PrivateRoute exact path="/greeting" component={Greeting} authorities={['xUSER']} />
 
 							{/* catch-all route is the 404 page */}
 							<Route component={Error404} />

--- a/scv-prototype-frontend/src/app/App.jsx
+++ b/scv-prototype-frontend/src/app/App.jsx
@@ -51,7 +51,7 @@ const App = (props) => {
 							<Route path="/sign-in" component={Login} exact />
 
 							{/* XXX :: GjB :: protected route for testing auth .. will remove later */}
-							<PrivateRoute exact path="/greeting" component={Greeting} authorities={['xUSER']} />
+							<PrivateRoute exact path="/greeting" component={Greeting} authorities={['USER']} />
 
 							{/* catch-all route is the 404 page */}
 							<Route component={Error404} />

--- a/scv-prototype-frontend/src/app/components/PrivateRoute/PrivateRoute.jsx
+++ b/scv-prototype-frontend/src/app/components/PrivateRoute/PrivateRoute.jsx
@@ -13,9 +13,9 @@ import Error403 from '../error/Error403';
  */
 const PrivateRoute = ({ authorities: requiredAuthorities, ...props }) => {
 	const { authenticationContext } = useContext(AuthenticationContext);
-	const { authenticated, authorities } = authenticationContext;
+	const { authenticated, authorities, tokenExpired } = authenticationContext;
 
-	if (!authenticated) {
+	if (!authenticated || tokenExpired) {
 		return (<Login />);
 	}
 

--- a/scv-prototype-frontend/src/app/components/PrivateRoute/PrivateRoute.jsx
+++ b/scv-prototype-frontend/src/app/components/PrivateRoute/PrivateRoute.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Route } from 'react-router-dom';
 import { AuthenticationContext } from '../../context/Authentication';
 import Login from '../../views/Login/Login';
+import Error403 from '../error/Error403';
 
 /**
  * Component that will redirect to a login page if
@@ -10,24 +11,27 @@ import Login from '../../views/Login/Login';
  * @author Greg Baker <gregory.j.baker@hrsdc-rhdcc.gc.ca>
  * @since 0.0.0
  */
-const PrivateRoute = ({ authorities, ...props }) => {
+const PrivateRoute = ({ authorities: requiredAuthorities, ...props }) => {
 	const { authenticationContext } = useContext(AuthenticationContext);
+	const { authenticated, authorities } = authenticationContext;
 
-	if (!authenticationContext.authenticated) {
+	if (!authenticated) {
 		return (<Login />);
 	}
 
-	if (authorities) {
-		const hasAuthority = authorities.filter((authority) => {
-			// this will effectively return the intersection of these two sets
-			return (authenticationContext.authorities || []).includes(authority)
-		}).length !== 0;
-
-		// TODO :: GjB :: render 403 page
-		if (!hasAuthority) { throw new Error('User not allowed access'); }
+	if (requiredAuthorities && intersection(requiredAuthorities)(authorities).length === 0) {
+		return (<Error403 />);
 	}
 
 	return (<Route {...props} />);
 };
+
+/**
+ * Array intersect (curried) function. Finds
+ * the intersection of two arrays.
+ *
+ * TODO :: GjB :: move to utility package?
+ */
+const intersection = (arr1) => (arr2) => (arr1 || []).filter((element) => (arr2 || []).includes(element));
 
 export default PrivateRoute;

--- a/scv-prototype-frontend/src/app/components/error/Error403/Error403.jsx
+++ b/scv-prototype-frontend/src/app/components/error/Error403/Error403.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { usePageMetadata } from '../../../context/PageMetadata';
+
+/**
+ * 403 Forbidden component that is very similar to what's used by canada.ca
+ *
+ * @author Greg Baker <gregory.j.baker@hrsdc-rhdcc.gc.ca>
+ * @since 0.0.0
+ */
+const Error403 = (props) => {
+	usePageMetadata({
+		documentTitle: 'Permission denied \u2016 Single client view',
+		pageIdentifier: 'SCV-0403-EN',
+		pageTitle: 'Permission denied'
+	});
+
+	return (
+		<p>You are not allowed to access that resource.</p>
+	);
+}
+
+export default Error403;

--- a/scv-prototype-frontend/src/app/components/error/Error403/index.jsx
+++ b/scv-prototype-frontend/src/app/components/error/Error403/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Error403';

--- a/scv-prototype-frontend/src/app/context/Authentication.jsx
+++ b/scv-prototype-frontend/src/app/context/Authentication.jsx
@@ -8,6 +8,7 @@ const initialState = {
 	authenticated: false,
 	authorities: [],
 	authToken: null,
+	tokenExpired: null,
 	username: 'Anonymous'
 };
 
@@ -53,3 +54,4 @@ const useAuthenticationContext = (authenticationContext) => {
 };
 
 export { AuthenticationContext, AuthenticationProvider, useAuthenticationContext };
+

--- a/scv-prototype-frontend/src/app/services/ApiService.jsx
+++ b/scv-prototype-frontend/src/app/services/ApiService.jsx
@@ -34,8 +34,12 @@ const apiService = {
 			headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${authToken}` }
 		});
 
+		if (response.status === 401) {
+			throw new InvalidTokenError('Invalid token or token has expired');
+		}
+
 		if (!response.ok) {
-			throw new Error('Error fetching greetings; response status: ' + response.status);
+			throw new InvalidTokenError('Error fetching greetings; response status: ' + response.status);
 		}
 
 		return await response.json();
@@ -58,4 +62,19 @@ const apiService = {
 	}
 };
 
+/**
+ * A custom error class intended to be thrown on authentication errors.
+ */
+class InvalidTokenError extends Error {
+
+	constructor(message) {
+		super(message);
+		this.message = message;
+		this.name="InvalidTokenError";
+	}
+
+};
+
 export default apiService;
+export { InvalidTokenError };
+

--- a/scv-prototype-frontend/src/app/views/Greeting/Greeting.jsx
+++ b/scv-prototype-frontend/src/app/views/Greeting/Greeting.jsx
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Loading from '../../components/Loading';
 import { AuthenticationContext } from '../../context/Authentication';
 import { usePageMetadata } from '../../context/PageMetadata';
 import apiService from '../../services/ApiService';
-import Loading from '../../components/Loading';
 
 /**
  * Component used for testing protected routes.
@@ -14,7 +14,7 @@ import Loading from '../../components/Loading';
  */
 const Greeting = (props) => {
 	const { t } = useTranslation();
-	const { authenticationContext } = useContext(AuthenticationContext);
+	const { authenticationContext, setAuthenticationContext } = useContext(AuthenticationContext);
 	const { authToken } = authenticationContext;
 
 	const [data, setData] = useState(null);
@@ -36,8 +36,12 @@ const Greeting = (props) => {
 			try {
 				setData(await apiService.fetchGreetings(authToken));
 			}
-			catch (error) {
+			catch (authError) {
 				setIsError(true);
+
+				if (authError.name === 'InvalidTokenError') {
+					setAuthenticationContext({ tokenExpired: true });
+				}
 			}
 
 			setIsLoading(false);
@@ -50,12 +54,15 @@ const Greeting = (props) => {
 			{isLoading ? (
 				<div className="text-center mrgn-tp-lg"><Loading /></div>
 			) : (
-					<div className="text-right">
-						<button className="btn btn-link btn-sm text-lowercase" onClick={() => { setFetchData(!fetchData) }}>
-							<i className="fas fa-sync"></i>&nbsp;&nbsp;{t("action.refresh")}
-						</button>
-					</div>
-				)}
+				<div className="text-right">
+					<button className="btn btn-link btn-sm text-lowercase" onClick={() => { setFetchData(!fetchData) }}>
+						<i className="fas fa-sync"></i>&nbsp;&nbsp;{t("action.refresh")}
+					</button>
+					<button className="btn btn-link btn-sm text-lowercase" onClick={() => setAuthenticationContext({ tokenExpired: true }) }>
+						<i className="fas fa-exclamation"></i>&nbsp;&nbsp;Simulate expired token
+					</button>
+				</div>
+			)}
 
 			{isError && (
 				<div className="alert alert-danger">

--- a/scv-prototype-frontend/src/app/views/Login/Login.jsx
+++ b/scv-prototype-frontend/src/app/views/Login/Login.jsx
@@ -12,7 +12,8 @@ import apiService from "../../services/ApiService";
  */
 const Login = (props) => {
 	const { t } = useTranslation();
-	const { setAuthenticationContext } = useContext(AuthenticationContext);
+	const { authenticationContext, setAuthenticationContext } = useContext(AuthenticationContext);
+	const { tokenExpired } = authenticationContext;
 
 	usePageMetadata({
 		documentTitle: t('login.document-title'),
@@ -41,7 +42,8 @@ const Login = (props) => {
 					authenticated: true,
 					username: username,
 					authorities: authorities,
-					authToken: authToken
+					authToken: authToken,
+					tokenExpired: false
 				});
 			}
 			catch (error) {
@@ -75,6 +77,11 @@ const Login = (props) => {
 				{authError && (
 					<div className="alert alert-danger">
 						<span>{t('login.bad-credentials')}</span>
+					</div>
+				)}
+				{tokenExpired && (
+					<div className="alert alert-danger">
+						<span>Your session has expired; please sign in again.</span>
 					</div>
 				)}
 				<div className="form-group">

--- a/scv-prototype-frontend/src/app/views/Login/Login.jsx
+++ b/scv-prototype-frontend/src/app/views/Login/Login.jsx
@@ -29,7 +29,8 @@ const Login = (props) => {
 	const handleSubmit = (event) => {
 		event.preventDefault();
 
-		const login = async () => {
+		(async () => {
+			setAuthError(false);
 			setIsBusy(true);
 
 			try {
@@ -48,9 +49,7 @@ const Login = (props) => {
 			}
 
 			setIsBusy(false);
-		}
-
-		login();
+		})();
 	};
 
 	return (


### PR DESCRIPTION
- New flag added to `AuthenticationContext`: `tokenExpired`
- API will now transform `401` responses into `ExpiredTokenError`
- View must catch `ExpiredTokenError` and set `authenticationContext.expiredToken=true`
- Login page consults the `expiredToken` flag and renders a login page if it's `true`